### PR TITLE
Add StripeGateway implementation

### DIFF
--- a/lib/stripe_gateway.dart
+++ b/lib/stripe_gateway.dart
@@ -1,0 +1,25 @@
+import 'payment_gateway.dart';
+
+/// Concrete Implementation A: Stripe-like gateway
+class StripeGateway implements PaymentGateway {
+  final String apiKey;
+
+  StripeGateway(this.apiKey);
+
+  @override
+  void processPayment(String orderId, double amount) {
+    // Different behavior (format + extra info)
+    print(
+      '[ImplA][StripeGateway] Charging \$${amount.toStringAsFixed(2)} for order $orderId via Stripe (apiKey=$apiKey)',
+    );
+    print('[ImplA][StripeGateway] -> status: succeeded (simulated)');
+  }
+
+  @override
+  void refundPayment(String orderId, double amount) {
+    print(
+      '[ImplA][StripeGateway] Refunding \$${amount.toStringAsFixed(2)} for order $orderId via Stripe',
+    );
+    print('[ImplA][StripeGateway] -> refund_id: rft_STRIPE_123 (simulated)');
+  }
+}


### PR DESCRIPTION
Summary:
- Added PaymentService consumer
- Implemented StripeGateway
- Created main.dart entrypoint to demonstrate gateway usage

How to test:
1. Pull the branch
2. Run: dart run lib/main.dart
3. Verify outputs for Stripe, Paypal, and Mock gateways

