### PR TITLE
Add PaypalGateway implementation to PaymentService demo

### DIFF
--- a/lib/paypal_gateway.dart
+++ b/lib/paypal_gateway.dart
@@ -1,0 +1,25 @@
+import 'payment_gateway.dart';
+
+/// Concrete Implementation B: PayPal-like gateway
+class PaypalGateway implements PaymentGateway {
+  final String clientId;
+
+  PaypalGateway(this.clientId);
+
+  @override
+  void processPayment(String orderId, double amount) {
+    // Different format/behavior than Stripe
+    print(
+      '[ImplB][PaypalGateway] Processing payment of \$${amount.toStringAsFixed(2)} for $orderId using PayPal (client=$clientId)',
+    );
+    print('[ImplB][PaypalGateway] -> transaction: PAYPAL_TXN_456 (simulated)');
+  }
+
+  @override
+  void refundPayment(String orderId, double amount) {
+    print(
+      '[ImplB][PaypalGateway] Issuing refund of \$${amount.toStringAsFixed(2)} for $orderId via PayPal',
+    );
+    print('[ImplB][PaypalGateway] -> refund_status: completed (simulated)');
+  }
+}


### PR DESCRIPTION
### Summary
- Added `PaypalGateway` implementation of the PaymentGateway interface
- Integrated it into `PaymentService` for processing and refunding payments
- Updated `main.dart` demo to include PayPal alongside Stripe and Mock gateways

### How to Test
1. Pull this branch
2. Run: dart analyze  (to check for errors)
3. Run: dart run lib/main.dart
4. Verify the console output shows:
   - Stripe payment + refund
   - PayPal payment + refund
   - Mock payment + refund
